### PR TITLE
Remove comment per page parameter from the frontend.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,12 +195,11 @@ E.g. ``Post`` model, as shown below:
 Step 2 - Adding template tags:
 ------------------------------
 
-``render_comments`` *tag uses 2 required and 2 optional args*:
+``render_comments`` *tag uses 2 required and 1 optional args*:
 
     1. Instance of the targeted model. (**Required**)
     2. Request object. (**Required**)
     3. oauth. (optional - Default is false)
-    4. comments_per_page (number of Comments Per Page - Default is 10)
 
 
 .. _Usage:
@@ -230,14 +229,14 @@ In the template (e.g. post_detail.) add the following template tags where ``obj`
 ^^^^^^^^^^^^^^^
 
 By default the comments will be paginated, 10 comments per page.
-To disabled the pagination pass ``comments_per_page=None``
-To change the default number, pass ``comments_per_page=number`` to ``render_comments``.
+To disable the pagination, set ``COMMENT_PER_PAGE=None`` in your settings file.
+To change the default number, set ``COMMENT_PER_PAGE=number``.
 
 .. code:: jinja
 
     {% load comment_tags %}  {# Loading the template tag #}
 
-    {% render_comments obj request comments_per_page=0 %}  {# Include all the comments belonging to a certain object #}
+    {% render_comments obj request %}  {# Include comments belonging to a certain object #}
     {% include_bootstrap %} {# Include bootstrap 4.1.1 - remove this line if BS 4.1.1 is already used in your project #}
     {% include_static %} {# Include comment CSS and JS files #}
 

--- a/comment/templates/comment/comments/comment_modal.html
+++ b/comment/templates/comment/comments/comment_modal.html
@@ -16,10 +16,9 @@
         <input name="model_name" value="{{model_name}}" hidden>
         <input name="model_id" value="{{model_id}}" hidden>
         <input name="app_name" value="{{app_name}}" hidden>
-        <input name="comments_per_page" value="{{comments_per_page}}" hidden>
         <input name="isParent" value="{{comment.is_parent}}" hidden>
         <input name="oauth" value="{{oauth}}" hidden>
-        <button id="modal-btn" type="submit" class="{% block del_btn_cls %}btn btn-danger{% endblock del_btn_cls %}" name={{comments_per_page}}>
+        <button id="modal-btn" type="submit" class="{% block del_btn_cls %}btn btn-danger{% endblock del_btn_cls %}">
             Delete
         </button>
     </div>

--- a/comment/templates/comment/comments/create_comment.html
+++ b/comment/templates/comment/comments/create_comment.html
@@ -10,7 +10,6 @@
             <input name="model_name" value="{% get_model_name model_object %}" hidden>
             <input name="model_id" value="{{ model_object.id }}" hidden>
             <input name="app_name" value="{% get_app_name model_object %}" hidden>
-            <input name="comments_per_page" value="{{comments_per_page}}" hidden>
             <input name="oauth" value="{{oauth}}" hidden>
             {% if comment %}
             <input name="parent_id" value="{{ comment.id }}" type="hidden"/>

--- a/comment/templates/comment/comments/delete_icon.html
+++ b/comment/templates/comment/comments/delete_icon.html
@@ -1,5 +1,5 @@
 {% load comment_tags %}
-<button title="Delete comment" class="js-comment-delete {% block delete_btn_cls %}btn btn-link{% endblock delete_btn_cls %}" data-url="{% url 'comment:delete' pk=comment.id %}?comments_per_page={{comments_per_page}}&model_name={% get_model_name model_object %}&model_id={{ model_object.id }}&app_name={% get_app_name model_object %}&oauth={{oauth}}">
+<button title="Delete comment" class="js-comment-delete {% block delete_btn_cls %}btn btn-link{% endblock delete_btn_cls %}" data-url="{% url 'comment:delete' pk=comment.id %}?model_name={% get_model_name model_object %}&model_id={{ model_object.id }}&app_name={% get_app_name model_object %}&oauth={{oauth}}">
 {% block delete_img_icon %}
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24"
      fill="none" stroke="{% block delete_icon_color %}#E74C3C{% endblock delete_icon_color %}"

--- a/comment/templates/comment/comments/edit_icon.html
+++ b/comment/templates/comment/comments/edit_icon.html
@@ -1,6 +1,6 @@
 {% load comment_tags %}
 <a title="Edit comment" class="js-comment-edit {% block edit_link_cls %}btn btn-link{% endblock edit_link_cls %}"
-   href="{% url 'comment:edit' pk=comment.id %}?comments_per_page={{comments_per_page}}&model_name={% get_model_name model_object %}&model_id={{ model_object.id }}&app_name={% get_app_name model_object %}&oauth={{oauth}}">
+   href="{% url 'comment:edit' pk=comment.id %}?model_name={% get_model_name model_object %}&model_id={{ model_object.id }}&app_name={% get_app_name model_object %}&oauth={{oauth}}">
 {% block edit_img_icon %}
 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
      stroke="{% block edit_icon_color %}#00bc8c{% endblock edit_icon_color %}"

--- a/comment/templates/comment/comments/update_comment.html
+++ b/comment/templates/comment/comments/update_comment.html
@@ -8,7 +8,6 @@
                 <input name="model_name" value="{% get_model_name model_object %}" hidden>
                 <input name="model_id" value="{{ model_object.id }}" hidden>
                 <input name="app_name" value="{% get_app_name model_object %}" hidden>
-                <input name="comments_per_page" value="{{comments_per_page}}" hidden>
                 <input name="oauth" value="{{oauth}}" hidden>
 
                 {% include 'comment/comments/apply_icon.html' %}

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -26,10 +26,9 @@ E.g. ``Post`` model, as shown below:
 Step 2 - Adding template tags:
 ------------------------------
 
-``render_comments`` *tag uses 2 required and 2 optional args*:
+``render_comments`` *tag uses 2 required and 1 optional arg*:
 
     1. Instance of the targeted model. (**Required**)
     2. Request object. (**Required**)
     3. oauth. (optional - Default is false)
-    4. comments_per_page (number of Comments Per Page - Default is 10)
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -23,14 +23,14 @@ In the template (e.g. post_detail.) add the following template tags where ``obj`
 ^^^^^^^^^^^^^^^
 
 By default, the comments will be paginated, 10 comments per page.
-To disable the pagination pass ``comments_per_page=None``
-To change the default number, pass ``comments_per_page=number`` to ``render_comments``.
+To disable the pagination, set ``COMMENT_PER_PAGE=None`` in your settings file.
+To change the default number, set ``COMMENT_PER_PAGE=number``.
 
 .. code:: jinja
 
     {% load comment_tags %}  {# Loading the template tag #}
 
-    {% render_comments obj request comments_per_page=0 %}  {# Include all the comments belonging to a certain object #}
+    {% render_comments obj request %}  {# Include comments belonging to a certain object #}
     {% include_bootstrap %} {# Include bootstrap 4.1.1 - remove this line if BS 4.1.1 is already used in your project #}
     {% include_static %} {# Include comment CSS and JS files #}
 


### PR DESCRIPTION
- since the parameter is directly taken from settings, it is no longer required here.
- update documentation accordingly.