### PR TITLE
Fix AJAX Mixing as per django-3.1 release

### DIFF
--- a/comment/mixins.py
+++ b/comment/mixins.py
@@ -10,6 +10,6 @@ class BaseCommentMixin(LoginRequiredMixin):
 
 class AJAXRequiredMixin:
     def dispatch(self, request, *args, **kwargs):
-        if not request.is_ajax():
+        if not request.headers.get('x-requested-with', None) == 'XMLHttpRequest':
             return HttpResponseBadRequest(_('Only AJAX request are allowed'))
         return super().dispatch(request, *args, **kwargs)


### PR DESCRIPTION
the function `request.is_ajax` is removed in `django` 3.1 according to the release text https://docs.djangoproject.com/en/3.1/releases/3.1/#id2