### PR TITLE
Add rest framework to installed apps

### DIFF
--- a/test/settings.py
+++ b/test/settings.py
@@ -17,6 +17,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.staticfiles',
     'django.contrib.messages',
+    'rest_framework',
     'comment',
     'post.apps.PostConfig',
     'user_profile.apps.AccountsConfig',


### PR DESCRIPTION
I believe this was mistakenly removed in an earlier commit.