### PR TITLE
Add mixin to test content type and parent_id parameters from the URL

### DIFF
--- a/comment/mixins.py
+++ b/comment/mixins.py
@@ -1,15 +1,113 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseBadRequest
+from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 
+from comment.models import Comment
+from comment.utils import get_data_for_request, get_response_for_bad_request
 
-# This willl be expanded to provide checks for validating the form fields
-class BaseCommentMixin(LoginRequiredMixin):
+
+class CommentUpdateMixin(LoginRequiredMixin):
     pass
 
 
 class AJAXRequiredMixin:
     def dispatch(self, request, *args, **kwargs):
         if not request.META.get('HTTP_X_REQUESTED_WITH', None) == 'XMLHttpRequest':
-            return HttpResponseBadRequest(_('Only AJAX request are allowed'))
+            return get_response_for_bad_request(why='Only AJAX request are allowed')
+        return super().dispatch(request, *args, **kwargs)
+
+
+class ContentTypeMixin:
+    """
+    When using this with DRF intialize `api=True` in the class.
+    Used for provinding validation of query parameters in request to match
+    a valid ContentType. Upon successful validation, `model_name`, `model_id`, `app_name`
+    can be accessed directly as class attributes.
+    """
+    api = False
+    error = ''
+
+    def _set_model_name_or_error(self, val):
+        if not val:
+            self.error = "model name must be provided"
+            return
+        self.model_name = val
+
+    def _set_model_id_or_error(self, val):
+        if not val:
+            self.error = "model id must be provided"
+            return
+        self.model_id = val
+
+    def _set_app_name_or_error(self, val):
+        if not val:
+            self.error = 'app name must be provided'
+            return
+
+        if not ContentType.objects.filter(app_label=val).exists():
+            self.error = f'{val} is NOT a valid app name'
+            return
+        self.app_name = val
+
+    def _set_error(self):
+        try:
+            model_name = self.model_name.lower()
+            ct = ContentType.objects.get(model=model_name).model_class()
+            model_class = ct.objects.filter(id=self.model_id)
+            if not model_class.exists() and model_class.count() != 1:
+                self.error = f"{self.model_id} is NOT a valid model id for the model {self.model_name}"
+        except ContentType.DoesNotExist:
+            self.error = f"{self.model_name} is NOT a valid model name"
+        except ValueError:
+            self.error = f"model id must be an integer, {self.model_id} is NOT"
+
+    def dispatch(self, request, *args, **kwargs):
+        data = get_data_for_request(request, self.api)
+        self._set_app_name_or_error(data.get('app_name'))
+        self._set_model_name_or_error(data.get('model_name'))
+        self._set_model_id_or_error(data.get('model_id'))
+        if not self.error:
+            self._set_error()
+        if self.error:
+            return get_response_for_bad_request(why=self.error, api=self.api)
+        return super().dispatch(request, *args, **kwargs)
+
+
+class ParentIdMixin:
+    """
+    When using this with DRF intialize `api=True` in the class.
+    Use this mixin only after ContentTypeMixin otherwise `model_id` might not be defined.
+    Used for provinding validation of query parameter `parent_id` in request to match
+    a valid parent comment. Upon successful validation, `parent_id` can be accessed
+    directly as a class attribute.
+    """
+    api = False
+    error = ''
+
+    def _clean_parent_id(self, val):
+        if not val or val == '0':
+            val = None
+        return val
+
+    def _set_parent_id_or_error(self, val):
+        if val:
+            model_id = self.data.get('model_id')
+            try:
+                if not Comment.objects.filter(id=val, object_id=model_id).exists():
+                    self.error = _(
+                        f'{val} is NOT a valid id for a parent comment or '
+                        'the parent comment does NOT belong to this model object'
+                        )
+                    return
+            except ValueError:
+                self.error = f"the parent id must be an integer, {val} is NOT"
+                return
+        self.parent_id = val
+
+    def dispatch(self, request, *args, **kwargs):
+        self.data = get_data_for_request(request, self.api)
+        parent_id = self._clean_parent_id(self.data.get('parent_id'))
+        self._set_parent_id_or_error(parent_id)
+        if self.error:
+            return get_response_for_bad_request(why=self.error, api=self.api)
         return super().dispatch(request, *args, **kwargs)

--- a/comment/tests/base.py
+++ b/comment/tests/base.py
@@ -255,3 +255,23 @@ class BaseCommentMigrationTest(TransactionTestCase):
             # get latest migration of current app
             migrate_to = [key for key in self.executor.loader.graph.leaf_nodes() if key[0] == self.app]
         self.executor.migrate(migrate_to)
+
+
+class BaseCommentMixinTest(BaseCommentTest):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.url_data = {
+            'model_name': 'post',
+            'app_name': 'post',
+            'model_id': 1
+        }
+
+    def get_url(self, base_url=None, **kwargs):
+        if not base_url:
+            base_url = self.base_url
+        if kwargs:
+            base_url += '?'
+            for (key, val) in kwargs.items():
+                base_url += str(key) + '=' + str(val) + '&'
+        return base_url.rstrip('&')

--- a/comment/tests/test_mixins.py
+++ b/comment/tests/test_mixins.py
@@ -1,0 +1,145 @@
+from rest_framework import status
+
+from comment.mixins import AJAXRequiredMixin, ContentTypeMixin, ParentIdMixin
+from comment.tests.base import BaseCommentMixinTest
+
+
+class AJAXMixinTest(BaseCommentMixinTest):
+    def setUp(self):
+        super().setUp()
+        self.mixin = AJAXRequiredMixin()
+
+    def test_non_ajax_request(self):
+        request = self.factory.get('/')
+        response = self.mixin.dispatch(request)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.content.decode('utf-8'), 'Only AJAX request are allowed')
+
+
+class ContentTypeMixinTest(BaseCommentMixinTest):
+    def setUp(self):
+        super().setUp()
+        self.mixin = ContentTypeMixin()
+        self.mixin.api = True
+        self.base_url = '/api/comments/'
+
+    def test_missing_app_name(self):
+        url_data = self.url_data.copy()
+        url_data.pop('app_name')
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, 'app name must be provided')
+
+    def test_missing_model_type(self):
+        url_data = self.url_data.copy()
+        url_data.pop('model_name')
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, 'model name must be provided')
+
+    def test_missing_model_id(self):
+        url_data = self.url_data.copy()
+        url_data.pop('model_id')
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, 'model id must be provided')
+
+    def test_invalid_model_name(self):
+        url_data = self.url_data.copy()
+        model_name = 'not exists'
+        url_data['model_name'] = model_name
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, f'{model_name} is NOT a valid model name')
+
+    def test_invalid_app_name(self):
+        url_data = self.url_data.copy()
+        app_name = 'not exists'
+        url_data['app_name'] = app_name
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, f'{app_name} is NOT a valid app name')
+
+    def test_model_id_does_not_exist(self):
+        url_data = self.url_data.copy()
+        model_id = 100
+        url_data['model_id'] = model_id
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, f'{model_id} is NOT a valid model id for the model {url_data["model_name"]}')
+
+    def test_model_id_non_integral(self):
+        url_data = self.url_data.copy()
+        model_id = 'not integral'
+        url_data['model_id'] = model_id
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, f'model id must be an integer, {model_id} is NOT')
+
+
+class TestParentIdMixin(BaseCommentMixinTest):
+    def setUp(self):
+        super().setUp()
+        self.create_comment(self.content_object_1)
+        self.create_comment(self.content_object_2)
+        self.mixin = ParentIdMixin()
+        self.mixin.api = True
+        self.base_url = '/api/comments/create/'
+
+    def test_parent_id_not_int(self):
+        # parent id not int
+        parent_id = 'c'
+        url_data = self.url_data.copy()
+        url_data['parent_id'] = parent_id
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self.mixin.error, f'the parent id must be an integer, {parent_id} is NOT')
+
+    def test_parent_id_does_not_exist(self):
+        parent_id = 100
+        url_data = self.url_data.copy()
+        url_data['parent_id'] = parent_id
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            self.mixin.error,
+            (
+                f'{parent_id} is NOT a valid id for a parent comment or '
+                'the parent comment does NOT belong to this model object'
+            )
+        )
+
+    def test_parent_id_does_not_belong_to_provided_model_type(self):
+        # parent id doesn't belong to the provided model type
+        parent_id = 100
+        url_data = self.url_data.copy()
+        url_data.update({'model_id': 2, 'parent_id': parent_id})
+        request = self.factory.get(self.get_url(**url_data))
+        response = self.mixin.dispatch(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            self.mixin.error,
+            (
+                f'{parent_id} is NOT a valid id for a parent comment or '
+                'the parent comment does NOT belong to this model object'
+            )
+        )

--- a/comment/tests/test_models.py
+++ b/comment/tests/test_models.py
@@ -229,6 +229,18 @@ class CommentModelManagerTest(BaseCommentManagerTest):
         count = Comment.objects.filter_parents_by_object(self.post_2, include_flagged=True).count()
         self.assertEqual(count, init_count)
 
+    def test_get_parent_comment(self):
+        # no parent_id passed from the url
+        self.assertIsNone(Comment.objects.get_parent_comment(''))
+        # no parent_id passed as 0
+        self.assertIsNone(Comment.objects.get_parent_comment('0'))
+        # no parent_id doesn't exist passed -> although this is highly unlikely as this will be handled by the mixin
+        # but is useful for admin interface if required
+        self.assertIsNone(Comment.objects.get_parent_comment(100))
+        parent_comment = Comment.objects.get_parent_comment(1)
+        self.assertIsNotNone(parent_comment)
+        self.assertEqual(parent_comment, self.parent_comment_1)
+
 
 class ReactionInstanceModelTest(BaseCommentManagerTest):
     def setUp(self):

--- a/comment/tests/test_views.py
+++ b/comment/tests/test_views.py
@@ -63,15 +63,6 @@ class CommentViewTestCase(BaseCommentViewTest):
         self.increase_count()
         self.comment_count_test()
 
-        # create child comment with wrong id of parent comment
-        data['parent_id'] = 100
-        response = self.client.post(self.get_url(), data=data)
-        self.assertEqual(response.status_code, 200)
-        # this is the latest comment
-        child_comment = Comment.objects.filter(object_id=self.post_1.id).order_by('-posted').first()
-        self.assertTrue(child_comment.is_parent)
-        self.assertIsNone(child_comment.parent)
-
     def test_create_comment_non_ajax_request(self):
         response = self.client_non_ajax.post(self.get_url(), data=self.data)
         self.assertEqual(response.status_code, 400)

--- a/comment/utils.py
+++ b/comment/utils.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from django.core import signing
 from django.apps import apps
 from django.contrib.sites.shortcuts import get_current_site
+from django.http import HttpResponseBadRequest
 
 from comment.conf import settings
 
@@ -213,3 +214,30 @@ def get_user_for_request(request):
     if request.user.is_authenticated:
         return request.user
     return None
+
+
+def get_data_for_request(request, api=False):
+    if api:
+        return request.GET
+    return request.POST
+
+
+def get_response_for_bad_request(*, why, api=False):
+    """Returns translated response for bad requests.
+    TODO: make this a `class CommentBadRequest`"""
+
+    def _get_api_response(why):
+        from rest_framework import status
+        from rest_framework.response import Response
+        from rest_framework.renderers import JSONRenderer
+        response = Response({'detail': why}, status=status.HTTP_400_BAD_REQUEST, content_type='application/json')
+        response.accepted_renderer = JSONRenderer()
+        response.accepted_media_type = "application/json"
+        response.renderer_context = {}
+        return response
+
+    why = _(why)
+    if api:
+        return _get_api_response(why)
+    else:
+        return HttpResponseBadRequest(why)

--- a/comment/views/comments.py
+++ b/comment/views/comments.py
@@ -13,7 +13,7 @@ from comment.forms import CommentForm
 from comment.utils import (
     get_comment_context_data, get_model_obj, is_comment_admin, is_comment_moderator,
     get_comment_from_key, process_anonymous_commenting, get_user_for_request, CommentFailReason)
-from comment.mixins import BaseCommentMixin, AJAXRequiredMixin
+from comment.mixins import CommentUpdateMixin, AJAXRequiredMixin, ContentTypeMixin, ParentIdMixin
 from comment.conf import settings
 
 
@@ -32,7 +32,7 @@ class BaseCommentView(AJAXRequiredMixin, FormView):
         return kw
 
 
-class CreateComment(BaseCommentView):
+class CreateComment(ContentTypeMixin, ParentIdMixin, BaseCommentView):
     comment = None
 
     def get_context_data(self, **kwargs):
@@ -47,11 +47,11 @@ class CreateComment(BaseCommentView):
             return ['comment/comments/child_comment.html']
 
     def form_valid(self, form):
-        app_name = self.request.POST.get('app_name')
-        model_name = self.request.POST.get('model_name')
-        model_id = self.request.POST.get('model_id')
+        app_name = self.app_name
+        model_name = self.model_name
+        model_id = self.model_id
         model_object = get_model_obj(app_name, model_name, model_id)
-        parent_id = self.request.POST.get('parent_id')
+        parent_id = self.parent_id
         parent_comment = Comment.objects.get_parent_comment(parent_id)
         user = get_user_for_request(self.request)
 
@@ -78,7 +78,7 @@ class CreateComment(BaseCommentView):
         return self.render_to_response(self.get_context_data())
 
 
-class UpdateComment(BaseCommentMixin, BaseCommentView):
+class UpdateComment(CommentUpdateMixin, BaseCommentView):
     comment = None
 
     def dispatch(self, request, *args, **kwargs):
@@ -102,7 +102,7 @@ class UpdateComment(BaseCommentMixin, BaseCommentView):
             return render(request, 'comment/comments/comment_content.html', context)
 
 
-class DeleteComment(BaseCommentMixin, BaseCommentView):
+class DeleteComment(CommentUpdateMixin, BaseCommentView):
     comment = None
 
     def dispatch(self, request, *args, **kwargs):

--- a/comment/views/flags.py
+++ b/comment/views/flags.py
@@ -7,10 +7,10 @@ from django.views import View
 from comment.conf import settings
 from comment.models import Comment, Flag, FlagInstance
 from comment.utils import is_comment_admin, is_comment_moderator
-from comment.mixins import BaseCommentMixin, AJAXRequiredMixin
+from comment.mixins import CommentUpdateMixin, AJAXRequiredMixin
 
 
-class FlagViewMixin(BaseCommentMixin, AJAXRequiredMixin, View):
+class FlagViewMixin(CommentUpdateMixin, AJAXRequiredMixin, View):
     comment = None
 
     def dispatch(self, request, *args, **kwargs):

--- a/comment/views/reactions.py
+++ b/comment/views/reactions.py
@@ -7,11 +7,11 @@ from django.views import View
 from django.views.decorators.http import require_POST
 
 from comment.models import Comment, Reaction, ReactionInstance
-from comment.mixins import BaseCommentMixin, AJAXRequiredMixin
+from comment.mixins import CommentUpdateMixin, AJAXRequiredMixin
 
 
 @method_decorator(require_POST, name='dispatch')
-class SetReaction(BaseCommentMixin, AJAXRequiredMixin, View):
+class SetReaction(CommentUpdateMixin, AJAXRequiredMixin, View):
 
     def post(self, request, *args, **kwargs):
         comment = get_object_or_404(Comment, id=kwargs.get('pk'))


### PR DESCRIPTION
- this works for both django and DRF.
- remove permissions that worked as mixin earlier for these parameters in drf, also corrects status code for wrong request to 400 from 403 in drf.
- add a module for testing mixin.
- add some other utility functions.