### PR TITLE
Fix links in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,12 +42,12 @@
 django-comments-dab
 ===================
 
-Full Documentations_
+Full Documentation_
 
-.. _Documentations: https://django-comment-dab.readthedocs.io/
+.. _Documentation: https://django-comment-dab.readthedocs.io/
 
 
-    .. image:: /docs/_static/img/comment.gif
+    .. image:: https://github.com/radi85/comment/blob/master/docs/_static/img/comment.gif
 
 
 Content:
@@ -226,9 +226,9 @@ In the template (e.g. post_detail.) add the following template tags where ``obj`
 2. Advanced usage:
 ------------------
 
-For advanced usage and other documentation, you may read the Documentations_ or look at the docs_ directory in the repository.
+For advanced usage and other documentation, you may read the Documentation_ or look at the docs_ directory in the repository.
 
-.. _docs: https://github.com/Radi85/Comment/tree/fix-readme/docs
+.. _docs: https://github.com/Radi85/Comment/tree/master/docs
 
 .. _Example:
 

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -112,3 +112,10 @@ COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Whether to use the first part of the email address as username for anonymous comments? For e.g. for ``user@domain``, ``user`` will be used. Defaults to ``False``.
+
+COMMENT_USE_GRAVATAR
+^^^^^^^^^^^^^^^^^^^^^
+
+Whether to use gravatar_ for displaying profile pictures alongside comments. Defaults to ``False``.
+
+.. _gravatar: https://gravatar.com/


### PR DESCRIPTION
- relative links don't work in the readme for PyPi, hence make all links made absolute.
- also add documentation regarding usage of gravatars.
- fix possible grammatical error in readme.