### PR TITLE
Make permission queries optional

### DIFF
--- a/comment/signals/post_migrate.py
+++ b/comment/signals/post_migrate.py
@@ -1,28 +1,31 @@
 from django.contrib.auth.models import Permission, Group
 from django.contrib.contenttypes.models import ContentType
 
+from comment.conf import settings
 from comment.models import Comment
 
 
 def create_permission_groups(sender, **kwargs):
-    comment_ct = ContentType.objects.get_for_model(Comment)
-    delete_comment_perm, __ = Permission.objects.get_or_create(
-        codename='delete_comment',
-        name='Can delete comment',
-        content_type=comment_ct
-    )
-    admin_group, __ = Group.objects.get_or_create(name='comment_admin')
-    admin_group.permissions.add(delete_comment_perm)
-    delete_flagged_comment_perm, __ = Permission.objects.get_or_create(
-        codename='delete_flagged_comment',
-        name='Can delete flagged comment',
-        content_type=comment_ct
-    )
-    moderator_group, __ = Group.objects.get_or_create(name='comment_moderator')
-    moderator_group.permissions.add(delete_flagged_comment_perm)
-    admin_group.permissions.add(delete_flagged_comment_perm)
+    if settings.COMMENT_FLAGS_ALLOWED:
+        comment_ct = ContentType.objects.get_for_model(Comment)
+        delete_comment_perm, __ = Permission.objects.get_or_create(
+            codename='delete_comment',
+            name='Can delete comment',
+            content_type=comment_ct
+        )
+        admin_group, __ = Group.objects.get_or_create(name='comment_admin')
+        admin_group.permissions.add(delete_comment_perm)
+        delete_flagged_comment_perm, __ = Permission.objects.get_or_create(
+            codename='delete_flagged_comment',
+            name='Can delete flagged comment',
+            content_type=comment_ct
+        )
+        moderator_group, __ = Group.objects.get_or_create(name='comment_moderator')
+        moderator_group.permissions.add(delete_flagged_comment_perm)
+        admin_group.permissions.add(delete_flagged_comment_perm)
 
 
 def adjust_flagged_comments(sender, **kwargs):
-    for comment in Comment.objects.all():
-        comment.flag.toggle_flagged_state()
+    if settings.COMMENT_FLAGS_ALLOWED:
+        for comment in Comment.objects.all():
+            comment.flag.toggle_flagged_state()

--- a/comment/tests/test_api.py
+++ b/comment/tests/test_api.py
@@ -501,9 +501,14 @@ class APICommentDetailForFlagStateChangeTest(APIBaseTest):
 
     @patch.object(settings, 'COMMENT_FLAGS_ALLOWED', 0)
     def test_change_state_when_flagging_is_disabled(self):
+        response = self.client.post(self.get_url(), data=self.data)
+        self.assertEqual(response.status_code, 403)
+
+    @patch.object(settings, 'COMMENT_FLAGS_ALLOWED', 1)
+    def test_change_state_when_comment_is_not_flagged(self):
         comment = self.comment_2
         self.assertFalse(comment.is_flagged)
-        response = self.client.post(self.get_url(), data=self.data)
+        response = self.client.post(self.get_url(comment.id), data=self.data)
         self.assertEqual(response.status_code, 400)
 
     def test_change_state_by_not_permitted_user(self):

--- a/comment/tests/test_utils.py
+++ b/comment/tests/test_utils.py
@@ -12,7 +12,7 @@ from comment.messages import EmailInfo
 from comment.utils import (
     get_model_obj, has_valid_profile, get_comment_context_data, id_generator, get_comment_from_key,
     get_user_for_request, send_email_confirmation_request, process_anonymous_commenting, CommentFailReason,
-    get_gravatar_img, get_profile_instance)
+    get_gravatar_img, get_profile_instance, is_comment_moderator, is_comment_admin)
 from comment.tests.base import BaseCommentUtilsTest, Comment, RequestFactory
 
 
@@ -131,6 +131,14 @@ class CommentUtilsTest(BaseCommentUtilsTest):
         self.assertEqual(comment_context_data['comments'].paginator.per_page, 2)
         self.assertTrue(comment_context_data['comments'].has_next())
         self.assertEqual(comment_context_data[oauth], False)
+
+    @patch.object(settings, 'COMMENT_FLAGS_ALLOWED', False)
+    def test_is_comment_moderator_no_moderation(self):
+        self.assertFalse(is_comment_moderator(self.moderator))
+
+    @patch.object(settings, 'COMMENT_FLAGS_ALLOWED', False)
+    def test_is_comment_admin_no_moderation(self):
+        self.assertFalse(is_comment_admin(self.admin))
 
     def test_user_for_request(self):
         request = self.factory.get('/')

--- a/comment/utils.py
+++ b/comment/utils.py
@@ -79,12 +79,20 @@ def has_valid_profile():
 
 
 def is_comment_admin(user):
-    return user.groups.filter(name='comment_admin').exists() or \
-           (user.has_perm('comment.delete_flagged_comment') and user.has_perm('comment.delete_comment'))
+    if settings.COMMENT_FLAGS_ALLOWED:
+        return user.groups.filter(name="comment_admin").exists() or (
+            user.has_perm("comment.delete_flagged_comment")
+            and user.has_perm("comment.delete_comment")
+        )
+    return False
 
 
 def is_comment_moderator(user):
-    return user.groups.filter(name='comment_moderator').exists() or user.has_perm('comment.delete_flagged_comment')
+    if settings.COMMENT_FLAGS_ALLOWED:
+        return user.groups.filter(name="comment_moderator").exists() or user.has_perm(
+            "comment.delete_flagged_comment"
+        )
+    return False
 
 
 def paginate_comments(comments, comments_per_page, current_page):

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -87,7 +87,6 @@ COMMENT_ALLOW_ANONYMOUS
 
 Should the anonymous commenting featured be allowed? Defaults to ``False``.
 
-
 COMMENT_FROM_EMAIL
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
PR related to issue #99: extra queries hit the database needlessly if the moderation feature is not being used. 