### PR TITLE
Fix version number according to PEP440

### DIFF
--- a/comment/__init__.py
+++ b/comment/__init__.py
@@ -1,1 +1,16 @@
+import os
+
+
+def _get_version():
+    _parent_project_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    with open(os.path.join(_parent_project_dir, 'VERSION')) as version_file:
+        version = version_file.read().strip()
+
+    if version.lower().startswith('v'):
+        version = version[1:]
+
+    return version
+
+
+__version__ = _get_version()
 default_app_config = 'comment.apps.CommentConfig'

--- a/comment/tests/test_version.py
+++ b/comment/tests/test_version.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch, mock_open
+
+from django.test import TestCase
+
+from comment import _get_version
+
+
+class TestGetVersion(TestCase):
+    def test_when_versions_startswith_v(self):
+        with patch('builtins.open', mock_open(read_data='v2.0.0'), create=True):
+            self.assertEqual('2.0.0', _get_version())
+
+    def test_when_versions_does_not_startwith_v(self):
+        with patch('builtins.open', mock_open(read_data='2.0.0'), create=True):
+            self.assertEqual('2.0.0', _get_version())

--- a/comment/urls.py
+++ b/comment/urls.py
@@ -1,11 +1,14 @@
 from django.urls import path, re_path
+from django.views.decorators.cache import cache_page
 from django.views.i18n import JavaScriptCatalog
 
+from comment import _get_version
 from comment.views import (
     CreateComment, UpdateComment, DeleteComment, SetReaction, SetFlag, ChangeFlagState,
     ConfirmComment)
 
 app_name = 'comment'
+
 
 urlpatterns = [
     path('create/', CreateComment.as_view(), name='create'),
@@ -16,5 +19,9 @@ urlpatterns = [
     path('<int:pk>/flag/state/change/', ChangeFlagState.as_view(), name='flag-change-state'),
     re_path(r'^confirm/(?P<key>[^/]+)/$', ConfirmComment.as_view(), name='confirm-comment'),
     # javascript translations
-    path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript-catalog'),
+    # The value returned by _get_version() must change when translations change.
+    path(
+        'jsi18n/',
+        cache_page(86400, key_prefix='js18n-%s' % _get_version())(JavaScriptCatalog.as_view()),
+        name='javascript-catalog'),
 ]


### PR DESCRIPTION
- version number is now a part of the package and can be accessed by `comment.__version__`.
- use this version when adding javascript urls for translation to improve performance. See: https://docs.djangoproject.com/en/dev/topics/i18n/translation/#note-on-performance