### PR TITLE
test: Use pytest for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ cache: pip
 
 python:
   - 3.6
-  - 3.7
-  - 3.8
+  - 3.9
 env:
   - DJANGO=2.1
-  - DJANGO=2.2
-  - DJANGO=3.0
   - DJANGO=3.1
   - DJANGO=master
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,7 +53,7 @@ To run tests against a particular ``python`` and ``django`` version installed in
 
 .. code:: bash
 
-    (venv) $ python manage.py test
+    (venv) $ pytest
 
 
 To run tests against all supported ``python`` and ``django`` versions, you may run:

--- a/comment/tests/test_utils.py
+++ b/comment/tests/test_utils.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 from unittest.mock import patch
 
 from django.utils import timezone
@@ -337,36 +336,34 @@ class TestProcessAnonymousCommenting(BaseAnonymousCommentTest, BaseCommentUtilsT
         self.assertEqual(EmailInfo.CONFIRMATION_SENT, response)
 
 
-class UtilsTest(TestCase):
+class TestUtils:
     """Test general purpose utilities that aren't necessarily related to a comment"""
-
-    def setUp(self):
-        self.len_id = 6
+    len_id = 6
 
     def test_id_generator_length(self):
-        self.assertEqual(self.len_id, len(id_generator()))
+        assert self.len_id == len(id_generator())
 
     def test_id_generator_generates_different_ids(self):
-        self.assertNotEqual(id_generator(), id_generator())
+        assert id_generator() != id_generator()
 
     def test_id_generator_prefix(self):
         prefix = 'comment'
         output = id_generator(prefix=prefix)
-        self.assertEqual(True, output.startswith(prefix))
-        self.assertEqual(self.len_id + len(prefix), len(output))
+        assert output.startswith(prefix) is True
+        assert self.len_id + len(prefix) == len(output)
 
     def test_id_generator_suffix(self):
         suffix = 'comment'
         output = id_generator(suffix=suffix)
-        self.assertEqual(True, output.endswith(suffix))
-        self.assertEqual(self.len_id + len(suffix), len(output))
+        assert output.endswith(suffix) is True
+        assert self.len_id + len(suffix) == len(output)
 
     def test_id_generator_chars(self):
-        import string   # flake8:no qa
+        import string
         chars = string.ascii_uppercase
         output = id_generator(chars=chars)
-        self.assertEqual(output, output.upper())
+        assert output == output.upper()
 
     def test_id_generator_len(self):
         len_id = 8
-        self.assertEqual(len_id, len(id_generator(len_id=len_id)))
+        assert len_id == len(id_generator(len_id=len_id))

--- a/comment/tests/test_version.py
+++ b/comment/tests/test_version.py
@@ -1,15 +1,14 @@
 from unittest.mock import patch, mock_open
 
-from django.test import TestCase
+import pytest
 
 from comment import _get_version
 
 
-class TestGetVersion(TestCase):
-    def test_when_versions_startswith_v(self):
-        with patch('builtins.open', mock_open(read_data='v2.0.0'), create=True):
-            self.assertEqual('2.0.0', _get_version())
-
-    def test_when_versions_does_not_startwith_v(self):
-        with patch('builtins.open', mock_open(read_data='2.0.0'), create=True):
-            self.assertEqual('2.0.0', _get_version())
+@pytest.mark.parametrize('version, expected', [
+    ('v2.0.0', '2.0.0'),
+    ('2.0.0', '2.0.0'),
+])
+def test_get_version(version, expected):
+    with patch('builtins.open', mock_open(read_data=version), create=True):
+        assert _get_version() == expected

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -53,7 +53,7 @@ To run tests against a particular ``python`` and ``django`` version installed in
 
 .. code:: bash
 
-    (venv) $ python manage.py test
+    (venv) $ pytest
 
 
 To run tests against all supported ``python`` and ``django`` versions, you may run:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
 [flake8]
 exclude = .git,*migrations*,test
 max-line-length = 120
+
+[tool:pytest]
+DJANGO_SETTINGS_MODULE = test.settings
+# Standard pytest options
+addopts = -p no:warnings --reuse-db
+python_paths = test/example

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],

--- a/test/example/requirements.txt
+++ b/test/example/requirements.txt
@@ -1,6 +1,9 @@
 django
 djangorestframework
 # used for testing/linting
+pytest-django
+pytest-cov
+pytest-pythonpath
 Pillow
 lxml
 beautifulsoup4

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,23 @@
 [tox]
 envlist =
-    py{36,37,38}-{django21, django22, django30, django31, djangomaster}
+    py{36,39}-{django21, django31, djangomaster}
 
 [travis]
 python =
     3.6: py36
-    3.7: py37
-    3.8: py38
+    3.9: py39
 
 [travis:env]
 DJANGO =
     2.1: django21
-    2.2: django22
-    3.0: django30
     3.1: django31
     master: djangomaster
 
 [testenv]
 deps =
-    coverage
+    pytest-django
+    pytest-pythonpath
+    pytest-cov
     flake8
     pillow
     djangorestframework
@@ -26,8 +25,6 @@ deps =
     beautifulsoup4
     cssselect
     django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     djangomaster: https://github.com/django/django/archive/master.tar.gz
 
@@ -40,7 +37,7 @@ commands =
     pip list
     flake8 comment/
     python manage.py migrate
-    coverage run manage.py test
+    coverage run -m pytest
     coverage report -m
 
 setenv =


### PR DESCRIPTION
- also fix some tests that required patching settings.
- reducing time for tox tests by running it for lesser environments(still cover all versions)
- add support for python3.9

fix #119
fix #112