### PR TITLE
ref(#144): Move common logic from views to mixin

### DIFF
--- a/comment/service/email.py
+++ b/comment/service/email.py
@@ -18,7 +18,7 @@ class DABEmailService(object):
         self.request = request
         self.sender = settings.COMMENT_FROM_EMAIL
         self.is_html = settings.COMMENT_SEND_HTML_EMAIL
-        self.thread = None
+        self._email_thread = None
 
     def get_msg_context(self, **context):
         context['comment'] = self.comment
@@ -34,8 +34,8 @@ class DABEmailService(object):
 
     def send_messages(self, messages):
         connection = get_connection()  # Use default email connection
-        self.thread = Thread(target=connection.send_messages, args=(messages,))
-        self.thread.start()
+        self._email_thread = Thread(target=connection.send_messages, args=(messages,))
+        self._email_thread.start()
 
     def get_message_templates(self, text_template, html_template, msg_context):
         text_msg_template = loader.get_template(text_template)

--- a/comment/tests/test_api/test_serializers.py
+++ b/comment/tests/test_api/test_serializers.py
@@ -153,10 +153,10 @@ class APICommentSerializers(APIBaseTest):
 
         serializer = CommentCreateSerializer(context=data)
         comment = serializer.create(validated_data={'content': 'test'})
-        self.assertTrue(serializer.email_service.thread.is_alive)
+        self.assertTrue(serializer.email_service._email_thread.is_alive)
         self.assertIsNotNone(comment)
-        self.assertIsNotNone(serializer.email_service.thread)
-        serializer.email_service.thread.join()
+        self.assertIsNotNone(serializer.email_service._email_thread)
+        serializer.email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 1)
 
     @patch.object(settings, 'COMMENT_ALLOW_ANONYMOUS', True)
@@ -182,8 +182,8 @@ class APICommentSerializers(APIBaseTest):
         self.assertIsNotNone(comment)
 
         # confirmation email is sent
-        self.assertIsNotNone(serializer.email_service.thread)
-        serializer.email_service.thread.join()
+        self.assertIsNotNone(serializer.email_service._email_thread)
+        serializer.email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 1)
 
     def test_passing_context_to_serializer(self):

--- a/comment/tests/test_api/test_views.py
+++ b/comment/tests/test_api/test_views.py
@@ -696,7 +696,7 @@ class APIConfirmCommentViewTest(BaseAnonymousCommentTest, APIBaseTest):
     def test_success_with_notification(self):
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        response.renderer_context['view'].email_service.thread.join()
+        response.renderer_context['view'].email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 1)
 
 

--- a/comment/tests/test_service.py
+++ b/comment/tests/test_service.py
@@ -102,13 +102,13 @@ class TestDABEmailService(BaseAnonymousCommentTest):
         self.assertEqual(len(mail.outbox), 0)
         self.email_service.send_messages(messages)
         self.assertNotEqual(len(mail.outbox), 100)
-        self.assertTrue(self.email_service.thread.is_alive())
-        self.email_service.thread.join()
+        self.assertTrue(self.email_service._email_thread.is_alive())
+        self.email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 100)
 
     def test_send_confirmation_request_django(self):
         self.email_service.send_confirmation_request()
-        self.email_service.thread.join()
+        self.email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 1)
         sent_email = mail.outbox[0]
         self.assertIsInstance(sent_email, EmailMultiAlternatives)
@@ -121,7 +121,7 @@ class TestDABEmailService(BaseAnonymousCommentTest):
 
     def test_send_confirmation_request_api(self):
         self.email_service.send_confirmation_request(api=True)
-        self.email_service.thread.join()
+        self.email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 1)
         sent_email = mail.outbox[0]
         self.assertIsInstance(sent_email, EmailMultiAlternatives)
@@ -175,7 +175,7 @@ class TestDABEmailService(BaseAnonymousCommentTest):
         self.assertEqual(followers.count(), 1)
 
         self.email_service.send_notification_to_followers()
-        self.email_service.thread.join()
+        self.email_service._email_thread.join()
 
         self.assertEqual(len(mail.outbox), 1)
         sent_email = mail.outbox[0]

--- a/comment/tests/test_views/test_comments.py
+++ b/comment/tests/test_views/test_comments.py
@@ -92,7 +92,7 @@ class CommentViewTestCase(BaseCommentViewTest):
         url = self.get_create_url()
         response = self.client.post(url, data=self.data)
         self.assertEqual(response.status_code, 200)
-        response.context['view'].email_service.thread.join()
+        response.context['view'].email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 1)
 
     def test_create_comment_non_ajax_request(self):
@@ -338,5 +338,5 @@ class ConfirmCommentViewTest(BaseAnonymousCommentTest):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response.url, comment.get_url(self.request))
 
-        view.email_service.thread.join()
+        view.email_service._email_thread.join()
         self.assertEqual(len(mail.outbox), 1)


### PR DESCRIPTION
- prevents duplication.
- also rename `thread` attribute in DABEmailService to `_email_thread` -> avoids confusion between comment thread and processing threads.

resolves #144