### PR TITLE
feat(#128): Allow custom user model fields

### DIFF
--- a/comment/api/serializers.py
+++ b/comment/api/serializers.py
@@ -166,15 +166,15 @@ class ReactionSerializer(serializers.ModelSerializer):
     def get_users(obj):
         users = {'likes': [], 'dislikes': []}
         for instance in obj.reactions.all():
+            user_info = {
+                'id': instance.user.id,
+                'username': instance.user.USERNAME_FIELD
+            }
+
             if instance.reaction_type == instance.ReactionType.LIKE:
-                users['likes'].append({
-                    'id': instance.user.id,
-                    'username': getattr(instance.user, instance.user.USERNAME_FIELD)
-                    })
+                users['likes'].append(user_info)
             else:
-                users['dislikes'].append({
-                    'id': instance.user.id, 'username': getattr(instance.user, instance.user.USERNAME_FIELD)
-                    })
+                users['dislikes'].append(user_info)
         return users
 
 
@@ -189,7 +189,11 @@ class FlagSerializer(serializers.ModelSerializer):
     @staticmethod
     def get_reporters(obj):
         return [
-            {'id': flag_instance.user.id, 'username': flag_instance.user.username} for flag_instance in obj.flags.all()
+            {
+                'id': flag_instance.user.id,
+                'username': flag_instance.user.USERNAME_FIELD
+            }
+            for flag_instance in obj.flags.all()
         ]
 
     @staticmethod

--- a/comment/managers/followers.py
+++ b/comment/managers/followers.py
@@ -1,8 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
-from comment.utils import get_username_for_comment
-
 
 class FollowerManager(models.Manager):
     def is_following(self, email, model_object):
@@ -31,7 +29,7 @@ class FollowerManager(models.Manager):
         """This method is used to set the comment's creator as a follower of own comment and the parent thread"""
         if not comment.email:
             return
-        username = get_username_for_comment(comment)
+        username = comment.get_username()
         model_object = comment
         if not comment.is_parent:
             model_object = comment.parent

--- a/comment/service/email.py
+++ b/comment/service/email.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from comment.conf import settings
 from comment.messages import EmailInfo
 from comment.models import Follower
-from comment.utils import get_username_for_comment
 
 
 class DABEmailService(object):
@@ -74,7 +73,7 @@ class DABEmailService(object):
         return str(self.comment.parent).split(':')[0]
 
     def get_subject_for_notification(self, thread_name):
-        username = get_username_for_comment(self.comment)
+        username = self.comment.get_username()
         return EmailInfo.NOTIFICATION_SUBJECT.format(username=username, thread_name=thread_name)
 
     def get_messages_for_notification(self, thread_name, receivers):

--- a/comment/templatetags/comment_tags.py
+++ b/comment/templatetags/comment_tags.py
@@ -4,7 +4,6 @@ from comment.models import ReactionInstance, FlagInstance, Follower
 from comment.forms import CommentForm
 from comment.utils import (
     is_comment_moderator, is_comment_admin, get_gravatar_img, get_profile_instance,
-    get_username_for_comment as get_username
 )
 from comment.managers import FlagInstanceManager
 from comment.messages import ReactionError
@@ -27,7 +26,7 @@ def get_app_name(obj):
 
 @register.simple_tag(name='get_username_for_comment')
 def get_username_for_comment(comment):
-    return get_username(comment)
+    return comment.get_username()
 
 
 @register.simple_tag(name='get_profile_url')

--- a/comment/tests/test_models/test_comments.py
+++ b/comment/tests/test_models/test_comments.py
@@ -141,6 +141,20 @@ class CommentModelTest(BaseCommentManagerTest):
             comment_url = comment.content_object.get_absolute_url() + '?page=2' + '#' + comment.urlhash
             self.assertEqual(comment_url, comment.get_url(request))
 
+    def test_get_username_for_non_anonymous_comment(self):
+        comment = self.create_comment(self.content_object_1, user=self.user_1)
+
+        self.assertEqual(comment.get_username(), comment.user.username)
+
+    def test_get_username_for_anonymous_comment(self):
+        comment = self.create_anonymous_comment()
+
+        with patch.object(settings, 'COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME', False):
+            self.assertEqual(comment.get_username(), settings.COMMENT_ANONYMOUS_USERNAME)
+
+        with patch.object(settings, 'COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME', True):
+            self.assertEqual(comment.get_username(), comment.email.split('@')[0])
+
 
 class CommentModelManagerTest(BaseCommentManagerTest):
 

--- a/comment/tests/test_service.py
+++ b/comment/tests/test_service.py
@@ -9,7 +9,6 @@ from comment.tests.test_utils import BaseAnonymousCommentTest
 from comment.service.email import DABEmailService
 from comment.messages import EmailInfo
 from comment.models import Follower
-from comment.utils import get_username_for_comment
 
 
 @patch.object(settings, 'COMMENT_ALLOW_ANONYMOUS', True)
@@ -180,7 +179,7 @@ class TestDABEmailService(BaseAnonymousCommentTest):
         self.assertEqual(len(mail.outbox), 1)
         sent_email = mail.outbox[0]
         self.assertIsInstance(sent_email, EmailMultiAlternatives)
-        username = get_username_for_comment(self.comment_obj)
+        username = self.comment_obj.get_username()
         thread_name = str(self.comment_obj.content_object)
         self.email_contents_test(sent_email.body, username, self.comment_obj.content)
         self.assertEqual(

--- a/comment/tests/test_template_tags.py
+++ b/comment/tests/test_template_tags.py
@@ -141,17 +141,23 @@ class CommentTemplateTagsTest(BaseTemplateTagsTest):
     @patch.object(settings, 'COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME', True)
     def test_get_username_for_comment_use_email_first_part_enabled(self):
         comment = self.create_comment(self.content_object_1, user=self.user_1)
-        anonymous_comment = self.create_anonymous_comment()
 
         self.assertEqual(get_username_for_comment(comment), comment.user.username)
+
+        # test for anonymous
+        anonymous_comment = self.create_anonymous_comment()
+
         self.assertEqual(get_username_for_comment(anonymous_comment), anonymous_comment.email.split('@')[0])
 
     @patch.object(settings, 'COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME', False)
     def test_get_username_for_comment_use_email_first_part_disabled(self):
         comment = self.create_comment(self.content_object_1, user=self.user_1)
-        anonymous_comment = self.create_anonymous_comment()
 
         self.assertEqual(get_username_for_comment(comment), comment.user.username)
+
+        # test for anonymous
+        anonymous_comment = self.create_anonymous_comment()
+
         self.assertEqual(get_username_for_comment(anonymous_comment), settings.COMMENT_ANONYMOUS_USERNAME)
 
 

--- a/comment/tests/test_utils.py
+++ b/comment/tests/test_utils.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from comment.conf import settings
 from comment.utils import (
     get_model_obj, has_valid_profile, id_generator, get_comment_from_key, get_user_for_request, CommentFailReason,
-    get_gravatar_img, get_profile_instance, is_comment_moderator, is_comment_admin, get_username_for_comment
+    get_gravatar_img, get_profile_instance, is_comment_moderator, is_comment_admin
 )
 from comment.tests.base import BaseCommentUtilsTest, Comment, RequestFactory
 
@@ -86,17 +86,6 @@ class CommentUtilsTest(BaseCommentUtilsTest):
         # test authenticated user
         request.user = self.user_1
         self.assertEqual(get_user_for_request(request), self.user_1)
-
-    def test_get_username_for_comment(self):
-        comment = self.create_comment(self.content_object_1, user=self.user_1)
-        anonymous_comment = self.create_anonymous_comment()
-
-        self.assertEqual(get_username_for_comment(comment), comment.user.username)
-        with patch.object(settings, 'COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME', False):
-            self.assertEqual(get_username_for_comment(anonymous_comment), settings.COMMENT_ANONYMOUS_USERNAME)
-
-        with patch.object(settings, 'COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME', True):
-            self.assertEqual(get_username_for_comment(anonymous_comment), anonymous_comment.email.split('@')[0])
 
 
 class BaseAnonymousCommentTest(BaseCommentUtilsTest):

--- a/comment/utils.py
+++ b/comment/utils.py
@@ -146,11 +146,3 @@ def get_user_for_request(request):
     if request.user.is_authenticated:
         return request.user
     return None
-
-
-def get_username_for_comment(comment):
-    if not comment.user:
-        if settings.COMMENT_USE_EMAIL_FIRST_PART_AS_USERNAME:
-            return comment.email.split('@')[0]
-        return settings.COMMENT_ANONYMOUS_USERNAME
-    return comment.user.username


### PR DESCRIPTION
- custom username and email fields set inside user model can now be used.

resolves #128