### PR TITLE
ci(#165): Solve CI issue with django master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: pip
 
 python:
   - 3.6
+  - 3.8
   - 3.9
 env:
   - DJANGO=2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 envlist =
-    py{36,39}-{django21, django31, djangomaster}
+    py{36, 39}-{django21, django31}
+    py{38, 39}-{djangomaster}
 
 [travis]
 python =
     3.6: py36
+    3.8: py38
     3.9: py39
 
 [travis:env]


### PR DESCRIPTION
- use python version >= 3.8 for the tests on the master branch of django.