### PR TITLE
chore: Rename default django branch to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 env:
   - DJANGO=2.1
   - DJANGO=3.1
-  - DJANGO=master
+  - DJANGO=main
 
 install: pip install tox-travis coveralls
 script:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,6 +4,17 @@ Contributing
 Django Comments Dab is developed and maintained by developers in an Open Source manner.
 Any support is welcome. You could help by writing documentation, pull-requests, report issues and/or translations.
 
+Starting points
+^^^^^^^^^^^^^^^^
+
+An issue with a `good first`_ label might be a good place to start with.
+
+You can also try to take up an issue tagged with an `upcoming release`_.
+
+.. _`good first`: https://github.com/Radi85/Comment/issues?q=is%3Aopen+is%3Aissue+label%3A"good+first+issue"
+.. _`upcoming release`: https://github.com/Radi85/Comment/milestones
+
+
 PR and commit messages
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -13,9 +24,7 @@ Refer to `#125`_
 
 .. _`#125`: https://github.com/Radi85/Comment/discussions/125
 
-In order to keep master clean and up to date with the current release, all PR shall be merged with ``develop-RELEASE_MILESTONE`` branch.
-
-``RELEASE_MILESTONE`` should be milestone tag of the issue you work on.
+In order to keep the default branch clean and up to date with the current release, all PR shall be merged with ``develop`` branch.
 
 **Commit messages**
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
     :target: https://coveralls.io/github/Radi85/Comment
     :alt: coverage
 
-.. image:: https://travis-ci.org/Radi85/Comment.svg?branch=master
+.. image:: https://travis-ci.org/Radi85/Comment.svg?branch=develop
     :target: https://travis-ci.org/Radi85/Comment
     :alt: build
 
@@ -23,7 +23,7 @@
     :alt: contributors
 
 .. image:: https://img.shields.io/github/license/radi85/Comment?color=gr
-    :target: https://github.com/Radi85/Comment/blob/master/LICENSE
+    :target: https://github.com/Radi85/Comment/blob/develop/LICENSE
     :alt: licence
 
 .. image:: https://img.shields.io/pypi/dm/django-comments-dab
@@ -43,7 +43,7 @@
 
 .. image:: https://img.shields.io/github/commits-since/radi85/comment/latest/develop
     :target: #
-    :alt: Commits since latest release for a branch master
+    :alt: Commits since latest release for a branch develop
 
 
 ===================
@@ -61,7 +61,7 @@ Full Documentation_
 .. _Documentation: https://django-comment-dab.readthedocs.io/
 
 
-    .. image:: https://github.com/radi85/comment/blob/master/docs/_static/img/comment.gif
+    .. image:: https://github.com/radi85/comment/blob/develop/docs/_static/img/comment.gif
 
 
 Content:
@@ -244,7 +244,7 @@ In the template (e.g. post_detail.) add the following template tags where ``obj`
 
 For advanced usage and other documentation, you may read the Documentation_ or look at the docs_ directory in the repository.
 
-.. _docs: https://github.com/Radi85/Comment/tree/master/docs
+.. _docs: https://github.com/Radi85/Comment/tree/develop/docs
 
 .. _Example:
 
@@ -293,4 +293,4 @@ Contributing
 
 For contributing, please see the instructions at Contributing_
 
-.. _Contributing: https://github.com/Radi85/Comment/blob/master/CONTRIBUTING.rst
+.. _Contributing: https://github.com/Radi85/Comment/blob/develop/CONTRIBUTING.rst

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36, 39}-{django21, django31}
-    py{38, 39}-{djangomaster}
+    py{38, 39}-{djangomain}
 
 [travis]
 python =
@@ -13,7 +13,7 @@ python =
 DJANGO =
     2.1: django21
     3.1: django31
-    master: djangomaster
+    main: djangomain
 
 [testenv]
 deps =
@@ -28,11 +28,11 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
-    djangomaster: https://github.com/django/django/archive/master.tar.gz
+    djangomain: https://github.com/django/django/archive/main.tar.gz
 
 usedevelop = True
 ignore_outcome =
-    djangomaster: True
+    djangomain: True
 
 commands =
     python -m pip install --upgrade pip


### PR DESCRIPTION
- also fix badges and older links to point to our develop branch.

closes #173