### PR TITLE
fix(#168): passing `request` object in template context

### DIFF
--- a/comment/templatetags/comment_tags.py
+++ b/comment/templatetags/comment_tags.py
@@ -78,7 +78,8 @@ def render_comments(obj, request, oauth=False):
     context = DABContext(request, model_object=obj)
     context.update({
         'comment_form': CommentForm(request=request),
-        'oauth': oauth
+        'oauth': oauth,
+        'request': request,
     })
     return context
 

--- a/comment/tests/test_template_tags.py
+++ b/comment/tests/test_template_tags.py
@@ -74,6 +74,8 @@ class CommentTemplateTagsTest(BaseTemplateTagsTest):
         # no pagination
         self.assertEqual(data['comments'].count(), count)  # parent comment only
         self.assertEqual(data['login_url'], settings.LOGIN_URL)
+        # check if `request` object is passed in context template
+        self.assertEqual(data['request'], request)
 
     @patch.object(settings, 'LOGIN_URL', None)
     def test_render_comments_without_login_url(self):


### PR DESCRIPTION
Set login url next parameter to absolute url of the model object.

fixes #168