### PR TITLE
fix: Response for state change on unflagged comments

### DIFF
--- a/comment/api/views.py
+++ b/comment/api/views.py
@@ -46,7 +46,7 @@ class CommentDetail(generics.RetrieveUpdateDestroyAPIView):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly, IsOwnerOrReadOnly, UserPermittedOrReadOnly)
 
 
-class CommentDetailForReaction(generics.RetrieveAPIView):
+class CommentDetailForReaction(generics.UpdateAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly, UserPermittedOrReadOnly)
@@ -74,7 +74,7 @@ class CommentDetailForReaction(generics.RetrieveAPIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class CommentDetailForFlag(generics.RetrieveAPIView):
+class CommentDetailForFlag(generics.UpdateAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly, FlagEnabledPermission, UserPermittedOrReadOnly)
@@ -98,7 +98,7 @@ class CommentDetailForFlag(generics.RetrieveAPIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class CommentDetailForFlagStateChange(generics.RetrieveAPIView):
+class CommentDetailForFlagStateChange(generics.UpdateAPIView):
     queryset = Comment.objects.all()
     serializer_class = CommentSerializer
     permission_classes = (CanChangeFlaggedCommentState, UserPermittedOrReadOnly)

--- a/comment/tests/test_api/test_permissions.py
+++ b/comment/tests/test_api/test_permissions.py
@@ -112,10 +112,15 @@ class CanChangeFlaggedCommentStateTest(BaseAPIPermissionsTest):
 
         self.assertFalse(self.permission.has_permission(self.request, self.view))
 
-    def test_cannot_change_state_for_unflagged_comment(self):
-        self.request.user = self.admin
+    def test_can_change_for_flagged_comment(self):
+        self.assertIs(
+            True,
+            self.permission.has_object_permission(self.request, self.view, self.flagged_comment)
+        )
 
-        self.assertFalse(
+    def test_cannot_change_for_unflagged_comment(self):
+        self.assertIs(
+            False,
             self.permission.has_object_permission(self.request, self.view, self.unflagged_comment)
         )
 

--- a/comment/tests/test_api/test_views.py
+++ b/comment/tests/test_api/test_views.py
@@ -320,6 +320,20 @@ class CommentDetailForReactionTest(BaseAPIViewTest):
             c_id = self.comment.id
         return reverse_lazy('comment-api:react', args=[c_id, reaction])
 
+    def test_cannot_update_comment_content(self):
+        comment = self.comment
+        original_content = comment.content
+        data = {'content': 'test updation during reactions'}
+
+        response = self.client.post(self.get_base_url(self.like), data=data, content_type='application/json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['content'], original_content)
+
+        # test database response
+        comment.refresh_from_db()
+
+        self.assertEqual(comment.content, original_content)
+
     def test_like(self):
         response = self.client.post(self.get_base_url(self.like))
 
@@ -509,7 +523,7 @@ class APICommentDetailForFlagStateChangeTest(BaseAPITest):
 
         response = self.client.post(self.get_base_url(comment.id), data=self.data)
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_by_not_permitted_user(self):
         self.client.force_login(self.user_1)


### PR DESCRIPTION
- also change use of `generics.RetrieveAPIView` to `generics.UpdateAPIView` in API views as these views were used to modify an instance.

- both of these changes only apply to the usage of REST API through DRF.