### PR TITLE
fix: Namespace pollution caused by star imports

### DIFF
--- a/comment/managers/__init__.py
+++ b/comment/managers/__init__.py
@@ -1,5 +1,17 @@
-# flake8: noqa
-from comment.managers.comments import *
-from comment.managers.reactions import *
-from comment.managers.flags import *
-from comment.managers.blocker import *
+from comment.managers.comments import CommentManager
+from comment.managers.reactions import ReactionManager, ReactionInstanceManager
+from comment.managers.flags import FlagManager, FlagInstanceManager
+from comment.managers.blocker import BlockedUserManager, BlockedUserHistoryManager
+from comment.managers.followers import FollowerManager
+
+
+__all__ = (
+    'CommentManager',
+    'ReactionManager',
+    'ReactionInstanceManager',
+    'FlagManager',
+    'FlagInstanceManager',
+    'BlockedUserManager',
+    'BlockedUserHistoryManager',
+    'FollowerManager',
+)

--- a/comment/models/__init__.py
+++ b/comment/models/__init__.py
@@ -1,6 +1,30 @@
-# flake8: noqa
-from comment.models.comments import *
-from comment.models.reactions import *
-from comment.models.flags import *
-from comment.models.followers import *
-from comment.models.blocker import *
+from comment.models.comments import Comment
+from comment.models.reactions import Reaction, ReactionInstance
+from comment.models.flags import Flag, FlagInstance
+from comment.models.followers import Follower
+from comment.models.blocker import BlockedUser, BlockedUserHistory
+from comment.managers import (
+    CommentManager, ReactionManager, ReactionInstanceManager, FlagManager, FlagInstanceManager, FollowerManager,
+    BlockedUserManager, BlockedUserHistoryManager,
+    )
+
+__all__ = (
+    'Comment',
+    'Reaction',
+    'ReactionInstance',
+    'Flag',
+    'FlagInstance',
+    'Follower',
+    'BlockedUser',
+    'BlockedUserHistory',
+    # TODO: managers are given here due to the earlier namespace pollutin caused by star imports,
+    # remove these along with their imports in v3.0.0
+    'CommentManager',
+    'ReactionManager',
+    'ReactionInstanceManager',
+    'FlagManager',
+    'FlagInstanceManager',
+    'FollowerManager',
+    'BlockedUserManager',
+    'BlockedUserHistoryManager',
+)

--- a/comment/tests/test_api/test_permissions.py
+++ b/comment/tests/test_api/test_permissions.py
@@ -9,7 +9,7 @@ from comment.api.permissions import (
     CanGetSubscribers, UserPermittedOrReadOnly, CanCreatePermission, CanBlockUsers
 )
 from comment.api.views import CommentList
-from comment.models import FlagInstanceManager
+from comment.managers import FlagInstanceManager
 from comment.conf import settings
 
 

--- a/comment/tests/test_api/test_views.py
+++ b/comment/tests/test_api/test_views.py
@@ -6,7 +6,8 @@ from django.urls import reverse_lazy
 from rest_framework import status
 
 from comment.conf import settings
-from comment.models import Comment, FlagInstanceManager, ReactionInstance
+from comment.models import Comment, ReactionInstance
+from comment.managers import FlagInstanceManager
 from comment.messages import ContentTypeError, EmailError, ReactionError
 from comment.api.serializers import CommentSerializer
 from comment.utils import get_model_obj

--- a/comment/views/__init__.py
+++ b/comment/views/__init__.py
@@ -1,7 +1,25 @@
-# flake8: noqa
-from comment.views.base import *
-from comment.views.comments import *
-from comment.views.reactions import *
-from comment.views.flags import *
-from comment.views.followers import *
-from comment.views.blocker import *
+from comment.views.base import BaseCommentView, CommentCreateMixin
+from comment.views.comments import CreateComment, UpdateComment, DeleteComment, ConfirmComment
+from comment.views.reactions import SetReaction
+from comment.views.flags import SetFlag, ChangeFlagState
+from comment.views.followers import BaseToggleFollowView, ToggleFollowView
+from comment.views.blocker import BaseToggleBlockingView, ToggleBlockingView
+
+
+__all__ = (
+    'BaseCommentView',
+    'CreateComment',
+    'UpdateComment',
+    'DeleteComment',
+    'ConfirmComment',
+    'SetReaction',
+    'SetFlag',
+    'ChangeFlagState',
+    'ToggleFollowView',
+    'ToggleBlockingView',
+    # TODO; remove these in v3.0.0, as these shouldn't necessarily be a part of public API, provided
+    # here for backward compatibility for pollution of namespace done by star imports(used earlier).
+    'BaseToggleBlockingView',
+    'BaseToggleFollowView',
+    'CommentCreateMixin',
+)


### PR DESCRIPTION
- use explicit imports and `__all__` to declare allowed list of public objects.
- some imports are still provided for backward compatibility, they may be removed in a major version bump.
- also, use correct packages for import of managers in tests.