### PR TITLE
test: Add python 3.7 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: pip
 
 python:
   - 3.6
+  - 3.7
   - 3.8
   - 3.9
 env:


### PR DESCRIPTION
- this was missed in 45425c4004d2f7a31762b5c8c24e047256c858ae.