### PR TITLE
chore: Add pytz as a dependency for tests

### DIFF
--- a/test/example/requirements.txt
+++ b/test/example/requirements.txt
@@ -1,5 +1,7 @@
 django
 djangorestframework
+# since django 4.0, pytz is no longer a dependency but is used for DRF
+pytz
 # used for testing/linting
 Pillow
 lxml

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands = flake8 comment
 deps =
     coverage
     pillow
+    pytz
     djangorestframework
     lxml
     beautifulsoup4


### PR DESCRIPTION
- since django 4.0, pytz is no longer a dependency, but is still required
  for rest framework.