### PR TITLE
chore: Handle deprecation warnings and drop support for EOL python and django versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,6 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/comment/__init__.py
+++ b/comment/__init__.py
@@ -1,4 +1,5 @@
 import os
+import django
 
 __version__ = '2.8.0'
 
@@ -23,4 +24,5 @@ def check_release():
 check_release()
 
 
-default_app_config = 'comment.apps.CommentConfig'
+if django.VERSION < (3, 2):
+    default_app_config = 'comment.apps.CommentConfig'

--- a/comment/conf/__init__.py
+++ b/comment/conf/__init__.py
@@ -1,7 +1,18 @@
+import django
 from django.conf import settings as django_settings
 from django.utils.functional import LazyObject
 
 from comment.conf import defaults as app_settings
+
+
+_django_version = django.VERSION
+DEPRECATED_SETTINGS = {
+    'PASSWORD_RESET_TIMEOUT_DAYS' if _django_version > (3, 0) else None,
+    'DEFAULT_CONTENT_TYPE' if _django_version > (2, 2) else None,
+    'FILE_CHARSET' if _django_version > (2, 2) else None,
+    'USE_L10N' if _django_version > (4, 0) else None,
+    'USE_TZ' if _django_version > (4, 0) else None,
+}
 
 
 class LazySettings(LazyObject):
@@ -13,7 +24,7 @@ class Settings(object):
     def __init__(self, *args):
         for item in args:
             for attr in dir(item):
-                if attr == attr.upper():
+                if attr.isupper() and attr not in DEPRECATED_SETTINGS:
                     setattr(self, attr, getattr(item, attr))
 
 

--- a/comment/templates/comment/anonymous/discarded.html
+++ b/comment/templates/comment/anonymous/discarded.html
@@ -1,6 +1,5 @@
 {% load comment_tags %}
 {% load i18n %}
-{% include_static %}
 {% include_bootstrap %}
 <html lang="en">
   <head>

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ license = MIT
 classifiers =
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 2.1
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Framework :: Django :: 3.1
@@ -26,7 +25,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/test/example/templates/z_base/script.html
+++ b/test/example/templates/z_base/script.html
@@ -2,4 +2,3 @@
 {% load comment_tags %}
 
 {% include_bootstrap %}
-{% include_static %}

--- a/test/settings/base.py
+++ b/test/settings/base.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import django
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 PROJECT_DIR = os.path.join(BASE_DIR, 'test/example')
@@ -72,7 +73,8 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
+if django.VERSION < (4, 0):
+    USE_L10N = True
 
 USE_TZ = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ usedevelop = True
 
 commands =
     python manage.py compilemessages -l test
-    python -m coverage run --parallel-mode manage.py test {posargs}
+    python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m coverage run --parallel-mode manage.py test {posargs}
 
 setenv =
     PYTHONDONTWRITEBYTECODE=1

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
 envlist =
-    py36-django{21, 22, 30, 31, 32}
-    py37-django{21, 22, 30, 31, 32}
-    py38-django{21, 22, 30, 31, 32, 40, main}
-    py39-django{21, 22, 30, 31, 32, 40, main}
+    py37-django{22, 30, 31, 32}
+    py38-django{22, 30, 31, 32, 40, main}
+    py39-django{22, 30, 31, 32, 40, main}
     py310-django{40, main}
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -38,7 +36,6 @@ deps =
     lxml
     beautifulsoup4
     cssselect
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
- since python 3.6 and django 2.1 had long reached
  end of life(EOL), we can safely remove support for
  them.

- also run tests that throw deprecation warnings as errors,
  so that these are caught earlier.
