### PR TITLE
test: Ignore results from django main branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -58,3 +58,12 @@ commands =
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     DJANGO_SETTINGS_MODULE=test.settings.test
+
+[testenv:py38-djangomain]
+ignore_outcome = true
+
+[testenv:py39-djangomain]
+ignore_outcome = true
+
+[testenv:py310-djangomain]
+ignore_outcome = true


### PR DESCRIPTION
- there are sometimes breaking changes introducted in django's
  main branch, that other dependencies take time to handle.
  For example: our CI has been broken for almost a month now,
  due to the breaking change in https://github.com/django/django/pull/15797.

  Hence, ignoring the results of the django main branch for now,
  to allow all other patches to be merged.