### PR TITLE
feat(#263): multiple comment fields in one page

### DIFF
--- a/comment/static/js/comment.js
+++ b/comment/static/js/comment.js
@@ -213,7 +213,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 // get parent element of the form with id=comments and replace html
                 var p = form.parentElement;while(p.id !== "comments"){var o = p;p = o.parentNode;};
                 p.outerHTML = result.data;
-                
             } else {
                 // child comment
                 let childComment = stringToDom(result.data, '.js-child-comment');

--- a/comment/static/js/comment.js
+++ b/comment/static/js/comment.js
@@ -211,8 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (formButton.getAttribute('value') === 'parent') {
                 // reload all comments only when posting parent comment
                 // get parent element of the form with id=comments and replace html
-                var p = form.parentElement;
-                while(p.id !== "comments"){var o = p;p = o.parentNode;};
+                var p = form.parentElement;while(p.id !== "comments"){var o = p;p = o.parentNode;};
                 p.outerHTML = result.data;
                 
             } else {
@@ -375,10 +374,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             if (isParent) {
-                    // get parent element of the form with id=comments and replace html
-                    var p = form.parentElement;
-                    while(p.id !== "comments"){var o = p;p = o.parentNode;};
-                    p.outerHTML = result.data;
+                // get parent element of the form with id=comments and replace html
+                var p = form.parentElement;while(p.id !== "comments"){var o = p;p = o.parentNode;};
+                p.outerHTML = result.data;
             } else {
                 // update replies count if a child was deleted
                 let replyNumberElement = getParentByClassName(commentElement, 'js-parent-comment').querySelector(".js-reply-number");

--- a/comment/static/js/comment.js
+++ b/comment/static/js/comment.js
@@ -210,7 +210,11 @@ document.addEventListener('DOMContentLoaded', () => {
             // parent comment
             if (formButton.getAttribute('value') === 'parent') {
                 // reload all comments only when posting parent comment
-                document.getElementById("comments").outerHTML = result.data;
+                // get parent element of the form with id=comments and replace html
+                var p = form.parentElement;
+                while(p.id !== "comments"){var o = p;p = o.parentNode;};
+                p.outerHTML = result.data;
+                
             } else {
                 // child comment
                 let childComment = stringToDom(result.data, '.js-child-comment');
@@ -371,7 +375,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             if (isParent) {
-                document.getElementById("comments").outerHTML = result.data;
+                    // get parent element of the form with id=comments and replace html
+                    var p = form.parentElement;
+                    while(p.id !== "comments"){var o = p;p = o.parentNode;};
+                    p.outerHTML = result.data;
             } else {
                 // update replies count if a child was deleted
                 let replyNumberElement = getParentByClassName(commentElement, 'js-parent-comment').querySelector(".js-reply-number");


### PR DESCRIPTION
#263 feat
adding code for getting form's parent '#comments' for supporting multiple comment fields in one page.
at > 
1) submitDeleteCommentForm
2) submitCommentCreateForm

if we use jquery this is possible with one line.
`$form.parents("section#comments").replaceWith(data);`
It can be used in old versions that uses jquery. It is working 100%.

_without this code when you try to post or delete comment while having more than one comment fields in one page, the posting comments(parent comments) from all the comment fiels get add to frist comment field, When deleting all the deleted fields get updated to first field._