### PR TITLE
feat(#267): Comments Editor value misplacing

### DIFF
--- a/comment/static/js/comment.js
+++ b/comment/static/js/comment.js
@@ -797,6 +797,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 event.preventDefault();
                 replyLink(event.target);
             } else if (event.target.closest('.js-comment-edit')) {
+                cancelEdit(document.querySelector(".js-comment-cancel"));
                 event.preventDefault();
                 setCommentForEditMode(event.target.closest('.js-comment-edit'));
             } else if (event.target.closest('.js-comment-cancel')) {


### PR DESCRIPTION
feat(#267): Comments Editor value misplacing
Only one line added.
This makes close of already opened comment edit form, before open new one.

Removed changes from >
feat(#263): multiple comment fields in one page.


added line
'cancelEdit(document.querySelector(".js-comment-cancel"));'